### PR TITLE
Windows branch: correct vrf

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In the block `trap`
 
 Parameter   | Description
 ------------|------------------------------------------------------------
-`vrf`      | Peak RF voltage, i.e. half the amplitude
+`vrf`      | Peak-to-peak RF voltage
 `vend`     | End-cap voltage
 `eta`      | Geometric non-ideality factor
 `r0`       | Distance between quadrupole rod centres

--- a/src/ccmdsim.cpp
+++ b/src/ccmdsim.cpp
@@ -111,7 +111,7 @@
  *
  *  Parameter   | Description
  *  ------------|------------------------------------------------------------
- *  \c vrf      | Peak RF voltage, i.e. half the amplitude
+ *  \c vrf      | Peak-to-peak RF voltage (29/9/15)
  *  \c vend     | End-cap voltage
  *  \c eta      | Geometric non-ideality factor
  *  \c r0       | Distance between quadrupole rod centres


### PR DESCRIPTION
These edits correct the labelling of vrf in the comments and the readme, correcting the outdated 'peak to zero' labelling with the corrected 'peak to peak' labelling.